### PR TITLE
feat(rate-limit): add global rate limiting for HTTP requests

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,28 @@ Both examples use `anuki.in` as the target domain. To use with your own store:
 2. Ensure your store is publicly accessible
 3. Verify your store has products and collections
 
+### Rate Limiting
+
+Examples can optionally enable the global rate limiter to avoid `429` responses when crawling:
+
+```typescript
+import { ShopClient, configureRateLimit } from '../src/index';
+
+configureRateLimit({
+  enabled: true,
+  maxRequestsPerInterval: 20,
+  intervalMs: 1000,
+  maxConcurrency: 4,
+  perHost: {
+    '*.myshopify.com': { maxRequestsPerInterval: 6, intervalMs: 1000, maxConcurrency: 3 },
+  },
+});
+
+const shop = new ShopClient('https://anuki.in');
+```
+
+Resolution order: class → host → default. See the main README for advanced configuration.
+
 ## 📊 Expected Output
 
 ### Basic Example Output

--- a/examples/advanced-usage.ts
+++ b/examples/advanced-usage.ts
@@ -1,6 +1,14 @@
-import { ShopClient } from "../src/index";
+import { configureRateLimit, ShopClient } from "../src/index";
 
 async function advancedUsageExample() {
+  // Enable and configure global rate limiting for all internal requests
+  configureRateLimit({
+    enabled: true,
+    maxRequestsPerInterval: 30, // 30 requests
+    intervalMs: 1000, // per second
+    maxConcurrency: 6, // up to 6 in parallel
+  });
+
   // Initialize the shop client with anuki.in domain
   const shop = new ShopClient("https://anuki.in");
 

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -4,10 +4,17 @@
  * This example demonstrates the basic functionality of the shop-search library
  * using the anuki.in Shopify store.
  */
+import { configureRateLimit, ShopClient } from "../src/index";
 
-import { ShopClient } from "../src/index";
 
 async function basicUsageExample() {
+  // Optional: enable a conservative global rate limiter to avoid 429s
+  configureRateLimit({
+    enabled: true,
+    maxRequestsPerInterval: 10,
+    intervalMs: 1000,
+    maxConcurrency: 3,
+  });
   // Initialize the shop client with anuki.in domain
   const shop = new ShopClient("https://anuki.in");
 

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -1,6 +1,7 @@
 import { filter, isNonNullish } from "remeda";
 import type { StoreInfo } from "./store";
 import type { Collection, Product, ShopifyCollection } from "./types";
+import { rateLimitedFetch } from "./utils/rate-limit";
 
 /**
  * Interface for collection operations
@@ -162,7 +163,7 @@ export function createCollectionOperations(
 
       try {
         const url = `${baseUrl}collections/${encodeURIComponent(sanitizedHandle)}.json`;
-        const response = await fetch(url);
+        const response = await rateLimitedFetch(url);
 
         if (!response.ok) {
           if (response.status === 404) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   safeParseDate,
   sanitizeDomain,
 } from "./utils/func";
+import { rateLimitedFetch } from "./utils/rate-limit";
 
 /**
  * A comprehensive Shopify store client for fetching products, collections, and store information.
@@ -525,7 +526,7 @@ export class ShopClient {
   ): Promise<Product[] | null> {
     try {
       const url = `${this.baseUrl}products.json?page=${page}&limit=${limit}`;
-      const response = await fetch(url);
+      const response = await rateLimitedFetch(url);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -548,7 +549,7 @@ export class ShopClient {
   private async fetchCollections(page: number, limit: number) {
     try {
       const url = `${this.baseUrl}collections.json?page=${page}&limit=${limit}`;
-      const response = await fetch(url);
+      const response = await rateLimitedFetch(url);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -575,7 +576,7 @@ export class ShopClient {
     try {
       const { page = 1, limit = 250 } = options;
       const url = `${this.baseUrl}collections/${collectionHandle}/products.json?page=${page}&limit=${limit}`;
-      const response = await fetch(url);
+      const response = await rateLimitedFetch(url);
 
       if (!response.ok) {
         if (response.status === 404) {
@@ -607,7 +608,7 @@ export class ShopClient {
 
     try {
       const url = `${this.baseUrl}products/${handle}.js`;
-      const response = await fetch(url, { method: "HEAD" });
+      const response = await rateLimitedFetch(url, { method: "HEAD" });
       const exists = response.ok;
 
       this.setCacheValue(cacheKey, exists);
@@ -630,7 +631,7 @@ export class ShopClient {
 
     try {
       const url = `${this.baseUrl}collections/${handle}.json`;
-      const response = await fetch(url, { method: "HEAD" });
+      const response = await rateLimitedFetch(url, { method: "HEAD" });
       const exists = response.ok;
 
       this.setCacheValue(cacheKey, exists);
@@ -724,7 +725,7 @@ export class ShopClient {
    */
   async getInfo(): Promise<StoreInfo> {
     try {
-      const response = await fetch(this.baseUrl);
+      const response = await rateLimitedFetch(this.baseUrl);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -1175,3 +1176,4 @@ export {
   safeParseDate,
   sanitizeDomain,
 } from "./utils/func";
+export { configureRateLimit } from "./utils/rate-limit";

--- a/src/products.ts
+++ b/src/products.ts
@@ -12,6 +12,7 @@ import {
   enrichProduct,
   generateSEOContent as generateSEOContentLLM,
 } from "./utils/enrich";
+import { rateLimitedFetch } from "./utils/rate-limit";
 
 /**
  * Interface for product operations
@@ -167,7 +168,7 @@ export function createProductOperations(
       const url = `${baseUrl}products.json?limit=${limit}&page=${page}`;
 
       try {
-        const response = await fetch(url);
+        const response = await rateLimitedFetch(url);
         if (!response.ok) {
           console.error(
             `HTTP error! status: ${response.status} for ${storeDomain} page ${page}`
@@ -246,7 +247,7 @@ export function createProductOperations(
         }
 
         const url = `${baseUrl}products/${encodeURIComponent(sanitizedHandle)}.js${qs ? `?${qs}` : ""}`;
-        const response = await fetch(url);
+        const response = await rateLimitedFetch(url);
 
         if (!response.ok) {
           if (response.status === 404) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { unique } from "remeda";
 import type { CountryDetectionResult, JsonLdEntry } from "./types";
 import { detectShopifyCountry } from "./utils/detect-country";
 import { extractDomainWithoutSuffix, generateStoreSlug } from "./utils/func";
+import { rateLimitedFetch } from "./utils/rate-limit";
 
 /**
  * Store operations interface for managing store-related functionality.
@@ -92,7 +93,7 @@ export function createStoreOperations(context: {
      */
     info: async (): Promise<StoreInfo> => {
       try {
-        const response = await fetch(context.baseUrl);
+        const response = await rateLimitedFetch(context.baseUrl);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/src/utils/enrich.ts
+++ b/src/utils/enrich.ts
@@ -6,6 +6,7 @@ import type {
   SEOContent,
   ShopifySingleProduct,
 } from "../types";
+import { rateLimitedFetch } from "./rate-limit";
 
 function ensureOpenRouter(apiKey?: string) {
   const key = apiKey || process.env.OPENROUTER_API_KEY;
@@ -48,7 +49,7 @@ export async function fetchAjaxProduct(
 ): Promise<ShopifySingleProduct> {
   const base = normalizeDomainToBase(domain);
   const url = `${base}/products/${handle}.js`;
-  const res = await fetch(url);
+  const res = await rateLimitedFetch(url);
   if (!res.ok) throw new Error(`Failed to fetch AJAX product: ${url}`);
   const data: ShopifySingleProduct = await res.json();
   return data;
@@ -63,7 +64,7 @@ export async function fetchProductPage(
 ): Promise<string> {
   const base = normalizeDomainToBase(domain);
   const url = `${base}/products/${handle}`;
-  const res = await fetch(url);
+  const res = await rateLimitedFetch(url);
   if (!res.ok) throw new Error(`Failed to fetch product page: ${url}`);
   return res.text();
 }
@@ -393,7 +394,7 @@ async function callOpenRouter(
       try {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 15000);
-        const response = await fetch(url, {
+        const response = await rateLimitedFetch(url, {
           method: "POST",
           headers,
           body: JSON.stringify(buildPayload(m)),

--- a/src/utils/rate-limit.ts
+++ b/src/utils/rate-limit.ts
@@ -1,0 +1,215 @@
+export interface RateLimitOptions {
+  maxRequestsPerInterval: number; // tokens refilled every interval
+  intervalMs: number; // refill period
+  maxConcurrency: number; // simultaneous in-flight requests
+}
+
+type Task<T> = {
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: any) => void;
+};
+
+class RateLimiter {
+  private options: RateLimitOptions;
+  private queue: Task<any>[] = [];
+  private tokens: number;
+  private inFlight = 0;
+  private refillTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: RateLimitOptions) {
+    this.options = options;
+    this.tokens = options.maxRequestsPerInterval;
+    this.startRefill();
+  }
+
+  private startRefill() {
+    if (this.refillTimer) return;
+    this.refillTimer = setInterval(() => {
+      this.tokens = this.options.maxRequestsPerInterval;
+      this.tryRun();
+    }, this.options.intervalMs);
+    // In some runtimes, timers keep process alive; make it best-effort
+    if (
+      this.refillTimer &&
+      typeof (this.refillTimer as any).unref === "function"
+    ) {
+      (this.refillTimer as any).unref();
+    }
+  }
+
+  configure(next: Partial<RateLimitOptions>) {
+    this.options = { ...this.options, ...next };
+    // Clamp to sensible minimums
+    this.options.maxRequestsPerInterval = Math.max(
+      1,
+      this.options.maxRequestsPerInterval
+    );
+    this.options.intervalMs = Math.max(10, this.options.intervalMs);
+    this.options.maxConcurrency = Math.max(1, this.options.maxConcurrency);
+  }
+
+  schedule<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({ fn, resolve, reject });
+      this.tryRun();
+    });
+  }
+
+  private tryRun() {
+    while (
+      this.queue.length > 0 &&
+      this.inFlight < this.options.maxConcurrency &&
+      this.tokens > 0
+    ) {
+      const task = this.queue.shift()!;
+      this.tokens -= 1;
+      this.inFlight += 1;
+
+      // Execute task and release slot when done
+      Promise.resolve()
+        .then(task.fn)
+        .then((result) => task.resolve(result))
+        .catch((err) => task.reject(err))
+        .finally(() => {
+          this.inFlight -= 1;
+          // Yield to event loop, then continue draining
+          setTimeout(() => this.tryRun(), 0);
+        });
+    }
+  }
+}
+
+let enabled = false;
+const defaultOptions: RateLimitOptions = {
+  maxRequestsPerInterval: 5, // 5 requests
+  intervalMs: 1000, // per second
+  maxConcurrency: 5, // up to 5 in parallel
+};
+
+const limiter = new RateLimiter(defaultOptions);
+const hostLimiters = new Map<string, RateLimiter>();
+const classLimiters = new Map<string, RateLimiter>();
+
+export type RateLimitedRequestInit = RequestInit & { rateLimitClass?: string };
+
+function getHost(input: RequestInfo | URL): string | undefined {
+  try {
+    if (typeof input === "string") {
+      return new URL(input).host;
+    }
+    if (input instanceof URL) {
+      return input.host;
+    }
+    // Request object or similar
+    const url = (input as any).url as string | undefined;
+    if (url) {
+      return new URL(url).host;
+    }
+  } catch {
+    // ignore parsing errors
+  }
+  return undefined;
+}
+
+function getHostLimiter(host?: string): RateLimiter | undefined {
+  if (!host) return undefined;
+  // Exact match first
+  const exact = hostLimiters.get(host);
+  if (exact) return exact;
+  // Wildcard suffix match: keys of the form '*.example.com'
+  for (const [key, lim] of hostLimiters.entries()) {
+    if (key.startsWith("*.") && host.endsWith(key.slice(2))) {
+      return lim;
+    }
+  }
+  return undefined;
+}
+
+export function configureRateLimit(
+  options: Partial<RateLimitOptions & { enabled: boolean }> & {
+    perHost?: Record<string, Partial<RateLimitOptions>>; // key: host (supports '*.example.com')
+    perClass?: Record<string, Partial<RateLimitOptions>>; // key: arbitrary class name
+  }
+) {
+  if (typeof options.enabled === "boolean") {
+    enabled = options.enabled;
+  }
+  const { perHost, perClass } = options;
+  const globalOpts: Partial<RateLimitOptions> = {};
+  if (typeof options.maxRequestsPerInterval === "number") {
+    globalOpts.maxRequestsPerInterval = options.maxRequestsPerInterval;
+  }
+  if (typeof options.intervalMs === "number") {
+    globalOpts.intervalMs = options.intervalMs;
+  }
+  if (typeof options.maxConcurrency === "number") {
+    globalOpts.maxConcurrency = options.maxConcurrency;
+  }
+  if (Object.keys(globalOpts).length) {
+    limiter.configure(globalOpts);
+  }
+  if (perHost) {
+    for (const host of Object.keys(perHost)) {
+      const opts = perHost[host]!;
+      const existing = hostLimiters.get(host);
+      if (existing) {
+        existing.configure(opts);
+      } else {
+        hostLimiters.set(
+          host,
+          new RateLimiter({
+            maxRequestsPerInterval:
+              opts.maxRequestsPerInterval ??
+              defaultOptions.maxRequestsPerInterval,
+            intervalMs: opts.intervalMs ?? defaultOptions.intervalMs,
+            maxConcurrency:
+              opts.maxConcurrency ?? defaultOptions.maxConcurrency,
+          })
+        );
+      }
+    }
+  }
+  if (perClass) {
+    for (const klass of Object.keys(perClass)) {
+      const opts = perClass[klass]!;
+      const existing = classLimiters.get(klass);
+      if (existing) {
+        existing.configure(opts);
+      } else {
+        classLimiters.set(
+          klass,
+          new RateLimiter({
+            maxRequestsPerInterval:
+              opts.maxRequestsPerInterval ??
+              defaultOptions.maxRequestsPerInterval,
+            intervalMs: opts.intervalMs ?? defaultOptions.intervalMs,
+            maxConcurrency:
+              opts.maxConcurrency ?? defaultOptions.maxConcurrency,
+          })
+        );
+      }
+    }
+  }
+}
+
+export async function rateLimitedFetch(
+  input: RequestInfo | URL,
+  init?: RateLimitedRequestInit
+): Promise<Response> {
+  if (!enabled) {
+    return fetch(input as any, init);
+  }
+  const klass = init?.rateLimitClass;
+  const byClass = klass ? classLimiters.get(klass) : undefined;
+  const byHost = getHostLimiter(getHost(input));
+  const eff = byClass ?? byHost ?? limiter;
+  return eff.schedule(() => fetch(input as any, init));
+}
+
+export function getRateLimitStatus() {
+  return {
+    enabled,
+    options: { ...defaultOptions },
+  };
+}


### PR DESCRIPTION
Implement token-bucket rate limiter with configurable thresholds and concurrency Add support for per-host and per-class rate limiting Update all internal fetch calls to use rateLimitedFetch Document usage in README and examples