### PR TITLE
ci(release): update node version to lts and switch to npx for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js (for npm provenance)
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Bun
@@ -75,4 +75,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           NPM_CONFIG_IGNORE_SCRIPTS: true
-        run: bun run semantic-release
+        run: npx semantic-release


### PR DESCRIPTION
Use LTS version of Node.js for better stability and maintenance. Replace bun with npx for semantic-release execution to simplify the workflow.