### PR TITLE
feat(build): enable subpath exports and lazy rate limiter initialisation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,6 +134,12 @@ configureRateLimit({
 });
 ```
 
+Tree-Shaking & Subpath Exports
+- The rate limiter’s timer starts lazily on first use; there are no import-time side effects.
+- The package declares `sideEffects: false` and provides subpath exports for deep imports:
+  - `shop-search/products`, `shop-search/collections`, `shop-search/checkout`, `shop-search/store`, `shop-search/rate-limit`
+- Prefer deep imports for smaller bundles and faster builds.
+
 Date handling policy:
 - Product `createdAt` / `updatedAt` use safe parsing and may be `undefined` when the source is invalid.
 - Product `publishedAt` is `Date | null` and defaults to `null` when unavailable or invalid.

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,6 +82,22 @@ const shop = new ShopClient('https://anuki.in');
 
 Resolution order: class → host → default. See the main README for advanced configuration.
 
+### Deep Imports
+
+Examples can deep import modules to reduce bundle size and speed up builds:
+
+```typescript
+// ESM
+import { configureRateLimit } from 'shop-search/rate-limit';
+import { fetchProducts } from 'shop-search/products';
+
+// CommonJS
+const { configureRateLimit } = require('shop-search/rate-limit');
+const { fetchProducts } = require('shop-search/products');
+```
+
+The library declares `sideEffects: false` and uses a lazily-started rate limiter timer, improving tree-shakeability.
+
 ## 📊 Expected Output
 
 ### Basic Example Output

--- a/package.json
+++ b/package.json
@@ -9,8 +9,34 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
+    },
+    "./products": {
+      "require": "./dist/products.js",
+      "import": "./dist/products.mjs",
+      "types": "./dist/products.d.ts"
+    },
+    "./collections": {
+      "require": "./dist/collections.js",
+      "import": "./dist/collections.mjs",
+      "types": "./dist/collections.d.ts"
+    },
+    "./checkout": {
+      "require": "./dist/checkout.js",
+      "import": "./dist/checkout.mjs",
+      "types": "./dist/checkout.d.ts"
+    },
+    "./store": {
+      "require": "./dist/store.js",
+      "import": "./dist/store.mjs",
+      "types": "./dist/store.d.ts"
+    },
+    "./rate-limit": {
+      "require": "./dist/rate-limit.js",
+      "import": "./dist/rate-limit.mjs",
+      "types": "./dist/rate-limit.d.ts"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: [
+    "src/index.ts",
+    "src/products.ts",
+    "src/collections.ts",
+    "src/checkout.ts",
+    "src/store.ts",
+    "src/utils/rate-limit.ts",
+  ],
   format: ["cjs", "esm"], // Support CommonJS and ESM
   dts: true, // Generate TypeScript declaration files
   sourcemap: true,


### PR DESCRIPTION
add subpath exports for better tree-shaking and smaller bundles make rate limiter timer start lazily on first use to avoid import-time side effects update documentation to reflect new deep import capabilities