### PR TITLE
fix(utils): validate domain suffixes in sanitizeDomain

### DIFF
--- a/.llm/api-reference.md
+++ b/.llm/api-reference.md
@@ -600,12 +600,16 @@ Utility functions are exported to support common normalization and parsing tasks
 import { sanitizeDomain } from 'shop-search';
 sanitizeDomain('https://WWW.Example.com/path?x=1#top'); // 'example.com'
 sanitizeDomain('www.example.com', { stripWWW: false }); // 'www.example.com'
+// sanitizeDomain('example'); // throws (invalid: missing public suffix)
 ```
 
 Normalizes domains by:
 - Lowercasing
 - Stripping protocol, path, query, fragment, and ports
 - Stripping `www.` by default (configurable via `stripWWW`)
+Throws for invalid inputs:
+- Empty strings or whitespace-only
+- Hostnames missing a public suffix (e.g., 'example')
 
 ### safeParseDate(input?)
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,13 @@ sanitizeDomain('https://www.example.com');            // "example.com"
 sanitizeDomain('www.example.com', { stripWWW: false }); // "www.example.com"
 sanitizeDomain('http://example.com/path');            // "example.com"
 
+// Errors on invalid input (e.g., bare hostname without suffix)
+try {
+  sanitizeDomain('example'); // throws
+} catch (e) {
+  console.error('Invalid domain');
+}
+
 // Safely parse dates (avoids Invalid Date)
 safeParseDate('2024-10-31T12:34:56Z');  // Date
 safeParseDate('');                      // undefined
@@ -513,6 +520,7 @@ safeParseDate('not-a-date');            // undefined
 
 Notes:
 - `sanitizeDomain` trims protocols, paths, and optional `www.` depending on `stripWWW`.
+- Throws for invalid inputs: empty strings or hostnames missing a public suffix (e.g., `example`).
 - `safeParseDate` returns `undefined` for invalid inputs; product `publishedAt` may be `null` when unavailable.
 
 #### Release and Publishing

--- a/src/__tests__/func.test.ts
+++ b/src/__tests__/func.test.ts
@@ -219,9 +219,14 @@ describe("Utility Functions", () => {
     });
 
     test("throws for empty input", () => {
-      expect(() => sanitizeDomain("")).toThrow();
+      expect(() => sanitizeDomain("" )) .toThrow();
       expect(() => sanitizeDomain("   ")).toThrow();
       expect(() => sanitizeDomain(undefined as any)).toThrow();
+    });
+
+    test("throws for bare hostnames without suffix", () => {
+      expect(() => sanitizeDomain("example")).toThrow();
+      expect(() => sanitizeDomain("www.example", { stripWWW: false })).toThrow();
     });
   });
 


### PR DESCRIPTION
Add validation to reject bare hostnames without public suffixes in sanitizeDomain function Update tests and documentation to reflect new validation behavior