### PR TITLE
build: migrate to esm-only and optimize bundle

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -131,6 +131,38 @@ npx semantic-release --dry-run
 
 Publishing to npm requires the GitHub Actions workflow with OIDC. Manual local publishes should not be used; rely on Trusted Publishing via CI.
 
+## 🧩 Manual Backfill Release (Tag/Notes Only)
+
+Use this when an npm version is already published and you need to align GitHub with a matching tag and release notes (no CI publish).
+
+### When to Use
+- You manually published or retagged a version on npm.
+- Semantic Release did not run (e.g., rename, provenance setup, or non-branch event).
+
+### Steps
+1. Ensure `CHANGELOG.md` has an entry for the version.
+2. Create the tag locally with the `v` prefix and push it:
+   ```bash
+   git tag -a vX.Y.Z -m "release: vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+3. Create the GitHub Release using the tag and notes:
+   ```bash
+   gh release create vX.Y.Z \
+     --title "vX.Y.Z" \
+     --notes "See CHANGELOG for details."
+   ```
+4. (Optional) Attach build artifacts for consumers who prefer direct downloads:
+   ```bash
+   bun run build
+   tar -czf dist-vX.Y.Z.tgz dist/
+   gh release upload vX.Y.Z dist-vX.Y.Z.tgz --clobber
+   ```
+
+### Important
+- This does not publish to npm; it only aligns Git tags and GitHub Releases.
+- Keep using branch pushes (`main`, `beta`) to trigger automated releases via CI.
+
 ## 📋 Troubleshooting
 
 ### Common Issues

--- a/package.json
+++ b/package.json
@@ -1,37 +1,32 @@
 {
   "name": "shop-client",
   "version": "3.8.2",
-  "main": "./dist/index.js",
+  "type": "module",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
     "./products": {
-      "require": "./dist/products.js",
       "import": "./dist/products.mjs",
       "types": "./dist/products.d.ts"
     },
     "./collections": {
-      "require": "./dist/collections.js",
       "import": "./dist/collections.mjs",
       "types": "./dist/collections.d.ts"
     },
     "./checkout": {
-      "require": "./dist/checkout.js",
       "import": "./dist/checkout.mjs",
       "types": "./dist/checkout.d.ts"
     },
     "./store": {
-      "require": "./dist/store.js",
       "import": "./dist/store.mjs",
       "types": "./dist/store.d.ts"
     },
     "./rate-limit": {
-      "require": "./dist/rate-limit.js",
       "import": "./dist/rate-limit.mjs",
       "types": "./dist/rate-limit.d.ts"
     }

--- a/src/products.ts
+++ b/src/products.ts
@@ -1,9 +1,5 @@
 import { filter, isNonNullish } from "remeda";
-import {
-  classifyProduct,
-  enrichProduct,
-  generateSEOContent as generateSEOContentLLM,
-} from "./ai/enrich";
+// Heavy AI enrich utilities are lazy-loaded where needed to keep base bundle light
 import type { StoreInfo } from "./store";
 import type {
   CurrencyCode,
@@ -372,6 +368,7 @@ export function createProductOperations(
 
       // Use the normalized handle from the found product
       const handle = baseProduct.handle;
+      const { enrichProduct } = await import("./ai/enrich");
       const enriched = await enrichProduct(storeDomain, handle, {
         apiKey,
         useGfm: options?.useGfm,
@@ -427,6 +424,7 @@ export function createProductOperations(
         // keep as-is if not JSON
       }
 
+      const { classifyProduct } = await import("./ai/enrich");
       const classification = await classifyProduct(productContent, {
         apiKey,
         model: options?.model,
@@ -459,6 +457,9 @@ export function createProductOperations(
         tags: baseProduct.tags,
       };
 
+      const { generateSEOContent: generateSEOContentLLM } = await import(
+        "./ai/enrich"
+      );
       const seo = await generateSEOContentLLM(payload, {
         apiKey,
         model: options?.model,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,8 +9,13 @@ export default defineConfig({
     "src/store.ts",
     "src/utils/rate-limit.ts",
   ],
-  format: ["cjs", "esm"], // Support CommonJS and ESM
-  dts: true, // Generate TypeScript declaration files
-  sourcemap: true,
-  clean: true, // Clean dist folder before build
+  format: ["esm"],
+  dts: true,
+  sourcemap: false,
+  minify: true,
+  treeshake: true,
+  target: "node18",
+  external: ["remeda", "tldts", "turndown", "turndown-plugin-gfm"],
+  splitting: true,
+  clean: true,
 });


### PR DESCRIPTION
- Remove cjs support and switch to esm-only format
- Enable minification, treeshaking and splitting for smaller bundle
- Lazy-load heavy AI utilities to reduce initial bundle size
- Update release guide with manual backfill instructions