### PR TITLE
ci: remove JSR publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,30 +88,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release
-
-  publish_jsr:
-    name: Publish to JSR
-    runs-on: ubuntu-latest
-    needs: release
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Sync jsr.json version from package.json
-        run: |
-          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); const jsr=JSON.parse(fs.readFileSync('jsr.json','utf8')); if(jsr.version!==pkg.version){jsr.version=pkg.version; fs.writeFileSync('jsr.json', JSON.stringify(jsr,null,2)+'\\n'); console.log('jsr.json version set to', jsr.version);} else {console.log('jsr.json version already', jsr.version);}" 
-
-      - name: Publish to JSR
-        run: npx jsr publish
+        


### PR DESCRIPTION
The workflow for publishing to JSR is no longer needed as we're focusing on npm releases only