### PR TITLE
feat(products): add content parameter to skip page fetching

### DIFF
--- a/.llm/api-reference.md
+++ b/.llm/api-reference.md
@@ -247,6 +247,28 @@ Fetches products featured on the store's homepage.
 const featuredProducts = await shop.products.showcased();
 ```
 
+### infoHtml()
+
+```typescript
+async infoHtml(productHandle: string, content?: string): Promise<string | null>
+```
+
+Fetches the extracted HTML content from the product page. This is useful for getting the main product description and content directly from the page HTML.
+
+**Parameters:**
+- `productHandle` (string): The product handle
+- `content` (string, optional): HTML content to extract from. If provided, skips fetching the product page.
+
+**Returns:** Promise resolving to extracted HTML content or null if not found
+
+**Example:**
+```typescript
+const html = await shop.products.infoHtml('awesome-t-shirt');
+
+// With provided content
+const htmlFromContent = await shop.products.infoHtml('awesome-t-shirt', '<html>...</html>');
+```
+
 ### filter()
 
 ```typescript
@@ -262,6 +284,95 @@ Extracts available filter options from all product variants (e.g., sizes, colors
 const filters = await shop.products.filter();
 // Returns: { "Size": ["S", "M", "L"], "Color": ["Red", "Blue", "Green"] }
 ```
+
+### enriched(productHandle: string, options?)
+
+```typescript
+async enriched(
+  productHandle: string,
+  options?: {
+    apiKey?: string;
+    useGfm?: boolean;
+    inputType?: "markdown" | "html";
+    model?: string;
+    outputFormat?: "markdown" | "json";
+    content?: string;
+  }
+): Promise<Product | null>
+```
+
+Merges product details from the API and the web page (or provided content) into a meaningful description.
+
+**Parameters:**
+- `productHandle` (string): The product handle
+- `options.content` (string, optional): HTML content to use instead of fetching the product page.
+- `options.outputFormat` (string, optional): "markdown" or "json" (default: "markdown").
+
+**Returns:** Promise resolving to a Product object with `enriched_content` field.
+
+### classify(productHandle: string, options?)
+
+```typescript
+async classify(
+  productHandle: string,
+  options?: {
+    apiKey?: string;
+    model?: string;
+    content?: string;
+  }
+): Promise<ProductClassification | null>
+```
+
+Classifies a product into structured categories (audience, vertical, etc.) using AI.
+
+**Parameters:**
+- `productHandle` (string): The product handle
+- `options.content` (string, optional): HTML content to use instead of fetching the product page.
+
+**Returns:** Promise resolving to `ProductClassification` object or null.
+
+### enrichedPrompts(productHandle: string, options?)
+
+```typescript
+async enrichedPrompts(
+  productHandle: string,
+  options?: {
+    useGfm?: boolean;
+    inputType?: "markdown" | "html";
+    outputFormat?: "markdown" | "json";
+    content?: string;
+  }
+): Promise<{ system: string; user: string }>
+```
+
+Generates the system and user prompts used for enrichment without calling the LLM.
+
+**Parameters:**
+- `productHandle` (string): The product handle
+- `options.content` (string, optional): HTML content to use.
+
+**Returns:** Object containing `system` and `user` prompt strings.
+
+### classifyPrompts(productHandle: string, options?)
+
+```typescript
+async classifyPrompts(
+  productHandle: string,
+  options?: {
+    useGfm?: boolean;
+    inputType?: "markdown" | "html";
+    content?: string;
+  }
+): Promise<{ system: string; user: string }>
+```
+
+Generates the system and user prompts used for classification without calling the LLM.
+
+**Parameters:**
+- `productHandle` (string): The product handle
+- `options.content` (string, optional): HTML content to use.
+
+**Returns:** Object containing `system` and `user` prompt strings.
 
 ## CollectionOperations
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,24 @@ const showcasedProducts = await shop.products.showcased();
 
 **Returns:** `Product[]` - Array of featured products
 
+#### `products.infoHtml(productHandle, content?)`
+
+Fetches the extracted HTML content from the product page. This is useful for getting the main product description and content directly from the page HTML.
+
+```typescript
+// Fetch from store
+const html = await shop.products.infoHtml("product-handle");
+
+// Use provided HTML
+const htmlFromContent = await shop.products.infoHtml("product-handle", "<html>...</html>");
+```
+
+**Parameters:**
+- `productHandle` (string): The product handle
+- `content` (string, optional): HTML content to extract from. If provided, skips fetching the product page.
+
+**Returns:** `Promise<string | null>` - Extracted HTML content or null if not found
+
 #### `products.filter()`
 
 Creates a map of variant options and their distinct values from all products in the store. This is useful for building filter interfaces, search facets, and product option selectors.
@@ -739,6 +757,12 @@ const enrichedMarkdown = await shop.products.enriched('some-product-handle', {
 });
 // enrichedMarkdown?.enriched_content → markdown
 
+// Use provided content instead of fetching product page
+const enrichedFromContent = await shop.products.enriched('some-product-handle', {
+  outputFormat: 'markdown',
+  content: '<html>...</html>',
+});
+
 const enrichedJson = await shop.products.enriched('some-product-handle', {
   outputFormat: 'json',
 });
@@ -747,6 +771,7 @@ const enrichedJson = await shop.products.enriched('some-product-handle', {
 // Build prompts without calling the LLM (useful for debugging)
 const { system, user } = await shop.products.enrichedPrompts('some-product-handle', {
   outputFormat: 'markdown',
+  content: '<html>...</html>', // Optional content
 });
 ```
 

--- a/src/__tests__/products.enrich.content.test.ts
+++ b/src/__tests__/products.enrich.content.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { ShopClient } from "../index";
+
+describe("Products Enrich Content", () => {
+  const domain = "test-shop.myshopify.com";
+  const handle = "test-product";
+  const providedContent = "<html><body><div id='shopify-section-template--main'><h1>Provided Content</h1></div></body></html>";
+  const ajaxResponse = {
+    id: 123,
+    title: "Test Product",
+    handle: handle,
+    description: "Original Description",
+    vendor: "Test Vendor",
+    variants: [],
+    images: [],
+    options: [],
+  };
+
+  // Mock fetch
+  const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+  (global as any).fetch = mockFetch;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    // Default mock implementation
+    mockFetch.mockImplementation((async (input: any) => {
+      const url = typeof input === "string" ? input : input?.url ?? "";
+      
+      // AJAX product request
+      if (url.includes(`/products/${handle}.js`)) {
+        return {
+          ok: true,
+          json: async () => ajaxResponse,
+        } as any;
+      }
+
+      // Product page request (should not be called if content provided)
+      if (url.endsWith(`/products/${handle}`)) {
+        return {
+          ok: true,
+          text: async () => "<html>Original Page Content</html>",
+        } as any;
+      }
+      
+      // OpenRouter mock
+      if (url.includes("openrouter.ai")) {
+        return {
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: JSON.stringify({ 
+              title: "Mocked Title",
+              description: "Mocked LLM Response",
+              category: "Mocked Category",
+              vertical: "clothing",
+              audience: "generic",
+              occasion: "casual",
+              brand: "MockBrand",
+              color: "blue",
+              material: "cotton",
+              pattern: "solid",
+              season: "summer",
+              style: "basic",
+              type: "shirt",
+              price_range: "medium",
+              tags: ["mock"],
+              sentiment: "positive"
+            }) } }],
+          }),
+        } as any;
+      }
+
+      return { ok: false, status: 404 } as any;
+    }) as any);
+  });
+
+  test("enriched() uses provided content and skips page fetch", async () => {
+    const shop = new ShopClient(`https://${domain}`, {
+      openRouter: { apiKey: "test-key", offline: false },
+    });
+
+    const result = await shop.products.enriched(handle, {
+      content: providedContent,
+      inputType: "html",
+    });
+
+    expect(result).toBeDefined();
+    // Verify AJAX was called
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/products/${handle}.js`),
+      expect.anything()
+    );
+    // Verify OpenRouter was called with provided content
+    const openRouterCall = mockFetch.mock.calls.find(call => 
+      call[0].toString().includes("openrouter.ai")
+    );
+    expect(openRouterCall).toBeDefined();
+    const body = JSON.parse(openRouterCall![1]?.body as string);
+    const messages = body.messages;
+    const userMessage = messages.find((m: any) => m.role === "user").content;
+    expect(userMessage).toContain("Provided Content");
+    expect(userMessage).not.toContain("Original Page Content");
+    // Verify fetch call count (1 for AJAX + maybe 0 for LLM if offline)
+    // If offline=true, it mocks response without fetch.
+  });
+
+  test("classify() uses provided content and skips page fetch", async () => {
+    const shop = new ShopClient(`https://${domain}`, {
+      openRouter: { apiKey: "test-key", offline: false },
+    });
+
+    const result = await shop.products.classify(handle, {
+      content: providedContent,
+    });
+
+    expect(result).toBeDefined();
+    // Verify AJAX was called
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/products/${handle}.js`),
+      expect.anything()
+    );
+    
+    // Verify OpenRouter was called with provided content
+    // Note: classify calls enriched() internally first (to get content), then classifyProduct()
+    // enriched() calls OpenRouter (1st call)
+    // classifyProduct() calls OpenRouter (2nd call)
+    
+    const openRouterCalls = mockFetch.mock.calls.filter(call => 
+      call[0].toString().includes("openrouter.ai")
+    );
+    expect(openRouterCalls.length).toBeGreaterThanOrEqual(1);
+    
+    // Check the first call (enrichment)
+    const body1 = JSON.parse(openRouterCalls[0][1]?.body as string);
+    const userMessage1 = body1.messages.find((m: any) => m.role === "user").content;
+    expect(userMessage1).toContain("Provided Content");
+    expect(userMessage1).not.toContain("Original Page Content");
+  });
+
+  test("enrichedPrompts() uses provided content", async () => {
+    const shop = new ShopClient(`https://${domain}`);
+
+    const result = await shop.products.enrichedPrompts(handle, {
+      content: providedContent,
+      inputType: "html",
+    });
+
+    expect(result).toBeDefined();
+    expect(result.user).toContain("Provided Content");
+    expect(result.user).not.toContain("Original Page Content");
+  });
+
+  test("classifyPrompts() uses provided content", async () => {
+    const shop = new ShopClient(`https://${domain}`);
+
+    const result = await shop.products.classifyPrompts(handle, {
+      content: providedContent,
+      inputType: "html",
+    });
+
+    expect(result).toBeDefined();
+    expect(result.user).toContain("Provided Content");
+    expect(result.user).not.toContain("Original Page Content");
+  });
+});

--- a/src/__tests__/products.infohtml.test.ts
+++ b/src/__tests__/products.infohtml.test.ts
@@ -1,0 +1,79 @@
+import { ShopClient } from "../index";
+
+describe("products.infoHtml", () => {
+  const domain = "examplestore.com";
+  const handle = "test-product";
+  const htmlContent = '<html><body><section id="shopify-section-template--main__main"><h1>Product Title</h1><p>Description</p></section></body></html>';
+  const expectedExtracted = '<section id="shopify-section-template--main__main"><h1>Product Title</h1><p>Description</p></section>';
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("fetches and extracts main section HTML", async () => {
+    (global as any).fetch = jest.fn(async (input: any) => {
+      const url = typeof input === "string" ? input : input?.url ?? "";
+      // Mock product JSON for find()
+      if (url.includes(`/products/${handle}.js`)) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 12345,
+            handle,
+            title: "Test Product",
+            options: [],
+            variants: [],
+            images: [],
+          }),
+        } as any;
+      }
+      // Mock product page HTML
+      if (url.includes(`/products/${handle}`)) {
+        return { ok: true, text: async () => htmlContent } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+
+    const shop = new ShopClient(`https://${domain}`);
+    const result = await shop.products.infoHtml(handle);
+    expect(result).toBe(expectedExtracted);
+  });
+
+  test("returns null if section not found", async () => {
+    (global as any).fetch = jest.fn(async (input: any) => {
+      const url = typeof input === "string" ? input : input?.url ?? "";
+      // Mock product JSON for find()
+      if (url.includes(`/products/${handle}.js`)) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 12345,
+            handle,
+            title: "Test Product",
+            options: [],
+            variants: [],
+            images: [],
+          }),
+        } as any;
+      }
+      if (url.includes(`/products/${handle}`)) {
+        return { ok: true, text: async () => "<html><body>No matching section</body></html>" } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+
+    const shop = new ShopClient(`https://${domain}`);
+    const result = await shop.products.infoHtml(handle);
+    expect(result).toBeNull();
+  });
+
+  test("uses provided content instead of fetching", async () => {
+    const fetchSpy = jest.fn();
+    (global as any).fetch = fetchSpy;
+
+    const shop = new ShopClient(`https://${domain}`);
+    const result = await shop.products.infoHtml(handle, htmlContent);
+    expect(result).toBe(expectedExtracted);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/ai/enrich.ts
+++ b/src/ai/enrich.ts
@@ -235,11 +235,17 @@ export async function buildEnrichPromptForProduct(
     useGfm?: boolean;
     inputType?: "markdown" | "html";
     outputFormat?: "markdown" | "json";
+    htmlContent?: string;
   }
 ): Promise<SystemUserPrompt> {
+  const ajaxProductPromise = fetchAjaxProduct(domain, handle);
+  const pageHtmlPromise = options?.htmlContent
+    ? Promise.resolve(options.htmlContent)
+    : fetchProductPage(domain, handle);
+
   const [ajaxProduct, pageHtml] = await Promise.all([
-    fetchAjaxProduct(domain, handle),
-    fetchProductPage(domain, handle),
+    ajaxProductPromise,
+    pageHtmlPromise,
   ]);
   const bodyHtml = ajaxProduct.description || "";
   const extractedHtml = extractMainSection(pageHtml);
@@ -263,11 +269,20 @@ export async function buildEnrichPromptForProduct(
 export async function buildClassifyPromptForProduct(
   domain: string,
   handle: string,
-  options?: { useGfm?: boolean; inputType?: "markdown" | "html" }
+  options?: {
+    useGfm?: boolean;
+    inputType?: "markdown" | "html";
+    htmlContent?: string;
+  }
 ): Promise<SystemUserPrompt> {
+  const ajaxProductPromise = fetchAjaxProduct(domain, handle);
+  const pageHtmlPromise = options?.htmlContent
+    ? Promise.resolve(options.htmlContent)
+    : fetchProductPage(domain, handle);
+
   const [ajaxProduct, pageHtml] = await Promise.all([
-    fetchAjaxProduct(domain, handle),
-    fetchProductPage(domain, handle),
+    ajaxProductPromise,
+    pageHtmlPromise,
   ]);
   const bodyHtml = ajaxProduct.description || "";
   const extractedHtml = extractMainSection(pageHtml);
@@ -674,12 +689,18 @@ export async function enrichProduct(
     model?: string;
     outputFormat?: "markdown" | "json";
     openRouter?: OpenRouterConfig;
+    htmlContent?: string;
   }
 ): Promise<EnrichedProductResult> {
   // STEP 1: Fetch Shopify single product (AJAX) and use its description
+  const ajaxProductPromise = fetchAjaxProduct(domain, handle);
+  const pageHtmlPromise = options?.htmlContent
+    ? Promise.resolve(options.htmlContent)
+    : fetchProductPage(domain, handle);
+
   const [ajaxProduct, pageHtml] = await Promise.all([
-    fetchAjaxProduct(domain, handle),
-    fetchProductPage(domain, handle),
+    ajaxProductPromise,
+    pageHtmlPromise,
   ]);
   const bodyHtml = ajaxProduct.description || "";
 


### PR DESCRIPTION
Add optional content parameter to product methods to allow using provided HTML content instead of fetching the product page. This enables offline usage and improves performance when content is already available.

Implement new infoHtml() method to extract main section HTML from product pages or provided content. Update tests and documentation accordingly.