### PR TITLE
fix(products): make apiKey required in findEnhanced options

### DIFF
--- a/src/__tests__/products.enhanced.test.ts
+++ b/src/__tests__/products.enhanced.test.ts
@@ -116,7 +116,10 @@ describe("products.findEnhanced", () => {
 
   test("throws when apiKey missing", async () => {
     const shop = new ShopClient(baseUrl);
+    // @ts-expect-error Testing runtime validation
     await expect(shop.products.findEnhanced(handle)).rejects.toThrow(/apiKey/i);
+    // @ts-expect-error Testing runtime validation
+    await expect(shop.products.findEnhanced(handle, {})).rejects.toThrow(/apiKey/i);
   });
 
   test("posts expected payload and returns response", async () => {

--- a/src/products.ts
+++ b/src/products.ts
@@ -50,12 +50,12 @@ export interface ProductOperations {
    *
    * @param productHandle - The handle of the product to find.
    * @param options - Options for the request.
-   * @param options.apiKey - API key for the enhancement service.
+   * @param options.apiKey - API key for the enhancement service. Required for authentication via x-api-key header.
    * @param options.endpoint - Optional custom endpoint URL for the enhancement service. Defaults to the standard worker URL.
    */
   findEnhanced(
     productHandle: string,
-    options?: { apiKey?: string; endpoint?: string }
+    options: { apiKey: string; endpoint?: string }
   ): Promise<EnhancedProductResponse | null>;
 
   /**
@@ -707,11 +707,19 @@ export function createProductOperations(
     return finalProducts ?? [];
   }
 
+  /**
+   * Internal implementation of findEnhanced.
+   *
+   * @param productHandle - The handle of the product to find.
+   * @param options - Options for the request.
+   * @param options.apiKey - API key for the enhancement service. Required for authentication via x-api-key header.
+   * @param options.endpoint - Optional custom endpoint URL for the enhancement service. Defaults to the standard worker URL.
+   */
   async function findEnhancedInternal(
     productHandle: string,
-    options?: { apiKey?: string; endpoint?: string }
+    options: { apiKey: string; endpoint?: string }
   ): Promise<EnhancedProductResponse | null> {
-    const apiKey = options?.apiKey;
+    const apiKey = options.apiKey;
     if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
       throw new Error("apiKey is required");
     }
@@ -880,7 +888,7 @@ export function createProductOperations(
 
     findEnhanced: async (
       productHandle: string,
-      options?: { apiKey?: string; endpoint?: string }
+      options: { apiKey: string; endpoint?: string }
     ): Promise<EnhancedProductResponse | null> =>
       findEnhancedInternal(productHandle, options),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -663,26 +663,49 @@ export type SEOContent = {
   marketingCopy: string;
 };
 
+/**
+ * Contextual image information extracted from product content.
+ */
 export type EnhancedProductImage = {
+  /** The text surrounding the image reference. */
   textContext: string;
+  /** The image URL. */
   url: string;
+  /** The image alt text. */
   alt: string;
 };
 
+/**
+ * Structured canonical product data extracted by AI.
+ */
 export type EnhancedProductCanonical = {
+  /** The product title. */
   title: string;
+  /** A brief summary of the product. */
   summary: string;
+  /** Key highlights or features of the product. */
   highlights: string[];
+  /** Material information (array of strings or object). */
   materials: unknown;
+  /** Fit and sizing information. */
   fit_and_size: unknown;
+  /** Care instructions. */
   care: unknown;
+  /** Unique selling points. */
   what_makes_it_special: unknown;
+  /** Information that was looked for but not found. */
   missing_info: unknown[];
+  /** List of contextual images found in the description. */
   images: EnhancedProductImage[];
 };
 
+/**
+ * The full enrichment result containing both structured and markdown formats.
+ */
 export type EnhancedProductEnrichment = {
+  /** The structured canonical data. */
   canonical: EnhancedProductCanonical;
+  /** The generated markdown content. */
   markdown: string;
 };
 

--- a/src/utils/rate-limit.ts
+++ b/src/utils/rate-limit.ts
@@ -240,6 +240,12 @@ export async function rateLimitedFetch(
     timeoutMs: _timeoutMs,
     ...fetchInit
   } = effInit;
+
+  // Default redirect to "follow" if not specified
+  if (fetchInit.redirect === undefined) {
+    fetchInit.redirect = "follow";
+  }
+
   const klass = init?.rateLimitClass;
   const byClass = klass ? classLimiters.get(klass) : undefined;
   const byHost = getHostLimiter(getHost(input));


### PR DESCRIPTION
Add runtime validation for apiKey in findEnhanced method and update type definitions. Also add missing JSDoc comments for types and internal functions.

Set default redirect behavior to "follow" in rateLimitedFetch when not specified.