### PR TITLE
feat(products): add variant images mapping to product types

### DIFF
--- a/src/__tests__/index.variant-options.test.ts
+++ b/src/__tests__/index.variant-options.test.ts
@@ -1,10 +1,10 @@
 import { ShopClient } from "../index";
 import type {
-  ShopifyImage,
-  ShopifyProduct,
-  ShopifyProductVariant,
-  ShopifySingleProduct,
-  ShopifySingleProductVariant,
+    ShopifyImage,
+    ShopifyProduct,
+    ShopifyProductVariant,
+    ShopifySingleProduct,
+    ShopifySingleProductVariant,
 } from "../types";
 
 describe("variantOptionsMap in product DTOs", () => {
@@ -66,7 +66,7 @@ describe("variantOptionsMap in product DTOs", () => {
       src: "https://example.com/img.jpg",
       position: 1,
       product_id: 1,
-      variant_ids: [],
+      variant_ids: ["1"],
     };
 
     const product: ShopifyProduct = {
@@ -97,6 +97,9 @@ describe("variantOptionsMap in product DTOs", () => {
       "color#blue##size#xl": "1",
       "color#red##size#xl": "2",
     });
+    expect(mapped.variantImages).toEqual({
+      "1": ["https://example.com/img.jpg"],
+    });
   });
 
   test("productDto includes variantOptionsMap with three options when present", () => {
@@ -117,7 +120,21 @@ describe("variantOptionsMap in product DTOs", () => {
         taxable: true,
         position: 1,
         product_id: 99,
-        featured_image: null,
+        featured_image: {
+          id: 10,
+          title: "variant",
+          handle: "variant",
+          src: "https://example.com/variant.jpg",
+          width: 0,
+          height: 0,
+          aspect_ratio: 1,
+          position: 1,
+          product_id: 99,
+          variant_ids: [101],
+          created_at: "2020-01-01T00:00:00Z",
+          updated_at: "2020-01-01T00:00:00Z",
+          alt: null,
+        },
         featured_media: null,
         available: true,
         price: "100",
@@ -172,6 +189,9 @@ describe("variantOptionsMap in product DTOs", () => {
     const mapped = shop.productDto(product);
     expect(mapped.variantOptionsMap).toEqual({
       "color#blue##material#cotton##size#m": "101",
+    });
+    expect(mapped.variantImages).toEqual({
+      "101": ["https://example.com/variant.jpg"],
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,6 +419,7 @@ export type Product = {
   updatedAt?: Date;
   variants: ProductVariant[] | null;
   images: ProductImage[];
+  variantImages: Record<string, string[]>;
   publishedAt: Date | null;
   seo?: MetaTag[] | null;
   metaTags?: MetaTag[] | null;
@@ -445,6 +446,7 @@ export type MinimalProduct = {
   discount: number;
   images: { src: string }[];
   featuredImage: string | null;
+  variantImages: Record<string, string[]>;
   available: boolean;
   localizedPricing: Pick<
     LocalizedPricing,


### PR DESCRIPTION
Implement variant images mapping functionality to associate product variants with their respective images. This includes:
- Adding variantImages field to Product and MinimalProduct types
- Creating buildVariantImagesMap utility function
- Updating product DTO mapping to include variant images
- Adding test cases for variant images mapping