### PR TITLE
refactor(variant-keys): change variant key separator from '#' to '__'

### DIFF
--- a/src/__tests__/func.test.ts
+++ b/src/__tests__/func.test.ts
@@ -1,13 +1,13 @@
 import {
-    buildVariantKey,
-    buildVariantOptionsMap,
-    calculateDiscount,
-    extractDomainWithoutSuffix,
-    generateStoreSlug,
-    genProductSlug,
-    normalizeKey,
-    safeParseDate,
-    sanitizeDomain,
+  buildVariantKey,
+  buildVariantOptionsMap,
+  calculateDiscount,
+  extractDomainWithoutSuffix,
+  generateStoreSlug,
+  genProductSlug,
+  normalizeKey,
+  safeParseDate,
+  sanitizeDomain,
 } from "../utils/func";
 
 describe("Utility Functions", () => {
@@ -287,9 +287,9 @@ describe("Utility Functions", () => {
 
       const map = buildVariantOptionsMap(optionNames, variants);
       expect(map).toEqual({
-        "color#blue##size#xl": "1",
-        "color#red##size#xl": "2",
-        "color#blue##size#l": "3",
+        "color__blue____size__xl": "1",
+        "color__red____size__xl": "2",
+        "color__blue____size__l": "3",
       });
     });
 
@@ -304,8 +304,8 @@ describe("Utility Functions", () => {
       const map = buildVariantOptionsMap(optionNames, variants);
       expect(map).toEqual({
         // first-write wins, duplicates are ignored
-        "size#xl": "10",
-        "size#l": "12",
+        "size__xl": "10",
+        "size__l": "12",
       });
     });
 
@@ -317,7 +317,7 @@ describe("Utility Functions", () => {
 
       const map = buildVariantOptionsMap(optionNames, variants);
       expect(map).toEqual({
-        "color#blue##material#cotton##size#m": "21",
+        "color__blue____material__cotton____size__m": "21",
       });
     });
   });
@@ -325,17 +325,17 @@ describe("Utility Functions", () => {
   describe("buildVariantKey", () => {
     test("builds key for two options and sorts alphabetically", () => {
       const key = buildVariantKey({ Size: "XL", Color: "Blue" });
-      expect(key).toBe("color#blue##size#xl");
+      expect(key).toBe("color__blue____size__xl");
     });
 
     test("handles single option", () => {
       const key = buildVariantKey({ Size: "XL" });
-      expect(key).toBe("size#xl");
+      expect(key).toBe("size__xl");
     });
 
     test("includes third option and normalizes values", () => {
       const key = buildVariantKey({ Size: "M", Color: "Blue", Material: "Cotton" });
-      expect(key).toBe("color#blue##material#cotton##size#m");
+      expect(key).toBe("color__blue____material__cotton____size__m");
     });
 
     test("ignores null/undefined values and returns empty for none", () => {

--- a/src/__tests__/index.variant-options.test.ts
+++ b/src/__tests__/index.variant-options.test.ts
@@ -94,12 +94,12 @@ describe("variantOptionsMap in product DTOs", () => {
     const mapped = mappedList![0];
 
     expect(mapped.variantOptionsMap).toEqual({
-      "color#blue##size#xl": "1",
-      "color#red##size#xl": "2",
+      "color__blue____size__xl": "1",
+      "color__red____size__xl": "2",
     });
     expect(mapped.variantPriceMap).toEqual({
-      "color#blue##size#xl": 10000,
-      "color#red##size#xl": 11000,
+      "color__blue____size__xl": 10000,
+      "color__red____size__xl": 11000,
     });
     expect(mapped.variantImages).toEqual({
       "1": ["https://example.com/img.jpg"],
@@ -192,10 +192,10 @@ describe("variantOptionsMap in product DTOs", () => {
 
     const mapped = shop.productDto(product);
     expect(mapped.variantOptionsMap).toEqual({
-      "color#blue##material#cotton##size#m": "101",
+      "color__blue____material__cotton____size__m": "101",
     });
     expect(mapped.variantPriceMap).toEqual({
-      "color#blue##material#cotton##size#m": 10000,
+      "color__blue____material__cotton____size__m": 10000,
     });
     expect(mapped.variantImages).toEqual({
       "101": ["https://example.com/variant.jpg"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -431,7 +431,7 @@ export type Product = {
   url: string;
   requiresSellingPlan?: boolean | null;
   sellingPlanGroups?: unknown;
-  variantOptionsMap: Record<string, string>; // Keys formatted as name#value parts joined by '##' (alphabetically sorted), e.g., "color#blue##size#xl"
+  variantOptionsMap: Record<string, string>; // Keys formatted as name__value parts joined by '____' (alphabetically sorted), e.g., "color__blue____size__xl"
   variantPriceMap: Record<string, number>;
   enriched_content?: string;
 };


### PR DESCRIPTION
Use double underscores for better readability and to avoid potential escaping issues in URLs and other contexts where '#' has special meaning. The change affects variant key generation in both product types and utility functions, with corresponding test updates.