### PR TITLE
feat(types): add variant availability map to product types

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ type Product = {
   variantOptionsMap: Record<string, string>;
   variantPriceMap: Record<string, number>;
   variantSkuMap: Record<string, string | null>;
+  variantAvailabilityMap: Record<string, boolean>;
 };
 ```
 
@@ -943,6 +944,7 @@ type Product = {
 - Each product includes `variantOptionsMap: Record<string, string>` when variants are present.
 - Each product includes `variantPriceMap: Record<string, number>` using the same keys; values are prices in cents.
 - Each product includes `variantSkuMap: Record<string, string | null>` using the same keys; values are SKUs (or `null`).
+- Each product includes `variantAvailabilityMap: Record<string, boolean>` using the same keys; values are availability flags.
 - Keys are composed of normalized option name/value pairs in the form `name__value`, joined by `____` and sorted alphabetically for stability.
 - Example: `{ "color__blue____size__xl": "123", "color__red____size__m": "456" }`.
 - Normalization uses `normalizeKey` (lowercases; spaces → `_`; non-space separators like `-` remain intact).
@@ -956,6 +958,7 @@ const key = buildVariantKey({ Size: "XL", Color: "Blue" }); // "color__blue____s
 const variantId = product.variantOptionsMap[key];
 const priceInCents = product.variantPriceMap[key];
 const sku = product.variantSkuMap[key];
+const available = product.variantAvailabilityMap[key];
 ```
 
 ### ProductVariant

--- a/src/__tests__/index.variant-options.test.ts
+++ b/src/__tests__/index.variant-options.test.ts
@@ -27,7 +27,7 @@ describe("variantOptionsMap in product DTOs", () => {
         position: 1,
         product_id: 1,
         featured_image: null,
-        available: true,
+        available: false,
         price: "100",
         weightInGrams: undefined,
         compare_at_price: undefined,
@@ -104,6 +104,10 @@ describe("variantOptionsMap in product DTOs", () => {
     expect(mapped.variantSkuMap).toEqual({
       "color__blue____size__xl": "SKU-XL-BLUE",
       "color__red____size__xl": "SKU-XL-RED",
+    });
+    expect(mapped.variantAvailabilityMap).toEqual({
+      "color__blue____size__xl": false,
+      "color__red____size__xl": true,
     });
     expect(mapped.variantImages).toEqual({
       "1": ["https://example.com/img.jpg"],
@@ -203,6 +207,9 @@ describe("variantOptionsMap in product DTOs", () => {
     });
     expect(mapped.variantSkuMap).toEqual({
       "color__blue____material__cotton____size__m": "SKU-M-BLUE-COTTON",
+    });
+    expect(mapped.variantAvailabilityMap).toEqual({
+      "color__blue____material__cotton____size__m": true,
     });
     expect(mapped.variantImages).toEqual({
       "101": ["https://example.com/variant.jpg"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,6 +434,7 @@ export type Product = {
   variantOptionsMap: Record<string, string>; // Keys formatted as name__value parts joined by '____' (alphabetically sorted), e.g., "color__blue____size__xl"
   variantPriceMap: Record<string, number>;
   variantSkuMap: Record<string, string | null>;
+  variantAvailabilityMap: Record<string, boolean>;
   enriched_content?: string;
 };
 
@@ -459,6 +460,7 @@ export type MinimalProduct = {
   variantOptionsMap: Record<string, string>;
   variantPriceMap: Record<string, number>;
   variantSkuMap: Record<string, string | null>;
+  variantAvailabilityMap: Record<string, boolean>;
   url: string;
   slug: string;
   platformId: string;


### PR DESCRIPTION
Add variantAvailabilityMap field to Product and MinimalProduct types to track availability per variant combination. Refactor variant map building utilities to extract common key generation logic into buildVariantKeyFromVariant function and add new buildVariantAvailabilityMap function. Update tests and documentation accordingly.

This enables clients to check variant availability using the same key format as other variant maps (variantOptionsMap, variantPriceMap, variantSkuMap).